### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/src/main/frontend/.dependabot/config.yml
+++ b/src/main/frontend/.dependabot/config.yml
@@ -1,0 +1,15 @@
+version: 1
+
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "chore"
+      include_scope: true
+  - package_manager: "javascript"
+    directory: "/src/main/frontend"
+    update_schedule: "live"
+    commit_message:
+      prefix: "chore"
+      include_scope: true


### PR DESCRIPTION
enable Dependabot to check updates on NPM and Gradle dependencies